### PR TITLE
Debugging and cleanup

### DIFF
--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -70,7 +70,7 @@ USAGE
   $ relay workflow:args:set -w <value> -s <value> [-a <value>] [-b <value>] [-r <value>]
 
 FLAGS
-  -s, --subscriber-id=<value>         (required) [default: 282b5c81-2410-4302-8f74-95207bdbe9d9] subscriber id
+  -s, --subscriber-id=<value>  (required) [default: 282b5c81-2410-4302-8f74-95207bdbe9d9] subscriber id
   -w, --workflow-id=<value>           (required) workflow id
   -a, --arg=<value>...                String name/value pair workflow arg
   -b, --boolean=arg1=[true|false]...  Boolean name/value pair workflow arg
@@ -426,7 +426,7 @@ FLAGS
       Number name/value pair workflow arg
 
   -s, --start=<value>
-      [default: 2023-11-10T13:00:00]
+      [default: 2023-12-01T12:00:00]
 
   -t, --[no-]transient
       Allow workflow to run in the background; otherwise terminate workflow
@@ -514,7 +514,7 @@ List workflow configurations
 
 ```
 USAGE
-  $ relay workflow:list -s <value> [--columns <value> | -x] [--sort <value>] [--filter <value>] [--output
+  $ relay workflow:list -s <value> [--json] [--columns <value> | -x] [--sort <value>] [--filter <value>] [--output
     csv|json|yaml |  | [--csv | --no-truncate]] [--no-header | ]
 
 FLAGS
@@ -528,6 +528,9 @@ FLAGS
   --output=<option>            output in a more machine friendly format
                                <options: csv|json|yaml>
   --sort=<value>               property to sort by (prepend '-' for descending)
+
+GLOBAL FLAGS
+  --json  Format output as json.
 
 DESCRIPTION
   List workflow configurations

--- a/src/commands/task/groups/create.ts
+++ b/src/commands/task/groups/create.ts
@@ -47,9 +47,8 @@ export default class TaskGroupsCreateCommand extends Command {
     try {
       const group = await createTaskGroup(taskGroupArgs)
       const success = await this.relay.createTaskGroup(subscriberId, group)
-
       if (success) {
-        this.log(`Successfully started created task group`)
+        this.log(`Successfully created task group`)
       } else {
         this.log(`Could not create task group`)
       }

--- a/src/lib/args.ts
+++ b/src/lib/args.ts
@@ -35,7 +35,7 @@ const createStartArgs = (args: string[]): StartArgs => {
 }
 
 const createTaskGroupArgs = (args: string[]): CreateTaskGroupArgs => {
-  return zipObject([`namespace`, `name`,`type`, `major`, `assignTo`, `members`], args) as CreateTaskGroupArgs
+  return zipObject([`namespace`,`type`, `major`, `name`, `assignTo`, `members`], args) as CreateTaskGroupArgs
 }
 
 const taskStartArgs = [
@@ -80,11 +80,6 @@ const taskGroupCreateArgs = [
     options: [`account`, `system`]
   },
   {
-    name: `name`,
-    required: true,
-    description: `Group name`
-  },
-  {
     name: `type`,
     required: true,
     description: `Task type`
@@ -93,6 +88,11 @@ const taskGroupCreateArgs = [
     name: `major`,
     required: true,
     description: `Major version`
+  },
+  {
+    name: `name`,
+    required: true,
+    description: `Group name`
   },
   {
     name: `assign-to`,

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -2,7 +2,7 @@
 
 import { CliUx } from '@oclif/core'
 import { forEach, reduce, get, isEmpty, times, find, indexOf, isArray, join, keys, map, replace, startsWith } from 'lodash'
-import { Geofence, Major, MergedWorkflowInstance, Minor, ScheduledTask, Task, TaskType, TaskArgs, Workflow, TaskGroup, TaskTypeDump } from './api'
+import { Geofence, Major, MergedWorkflowInstance, Minor, ScheduledTask, Task, TaskType, TaskArgs, Workflow, TaskGroup, TaskTypeDump, WorkflowEvents, WorkflowEvent } from './api'
 
 import { ALL, RESOURCE_PREFIX } from './constants'
 
@@ -121,7 +121,7 @@ const displayInstall = (workflow: Workflow) => {
 
 export const printWorkflows = (workflows: Workflow[], flags: unknown): void => {
   const options = { ...(flags as Record<string, unknown>) }
-  CliUx.ux.styledHeader(`Installed Workflow${workflows.length > 1 ? `s` : ``}`)
+  options.output ?? CliUx.ux.styledHeader(`Installed Workflow${workflows.length > 1 ? `s` : ``}`)
   CliUx.ux.table(workflows, {
     workflow_id: {
       header: `ID`,
@@ -148,7 +148,7 @@ export const printWorkflows = (workflows: Workflow[], flags: unknown): void => {
 
 export const printGeofences = (geofences: Geofence[], flags: unknown): void => {
   const options = { ...(flags as Record<string, unknown>) }
-  CliUx.ux.styledHeader(`Configured geofence${geofences.length > 1 ? `s` : ``}`)
+  options.output ?? CliUx.ux.styledHeader(`Configured geofence${geofences.length > 1 ? `s` : ``}`)
   CliUx.ux.table(geofences, {
     geofence_id: {
       header: `ID`,
@@ -209,7 +209,7 @@ export const printWorkflowInstances = (instances: MergedWorkflowInstance[], flag
 
 export const printTasks = (tasks: Task[], flags: unknown): void => {
   const options = { ...(flags as Record<string, unknown>) }
-  CliUx.ux.styledHeader(`Installed Task${tasks.length > 1 ? `s` : ``}`)
+  options.output ?? CliUx.ux.styledHeader(`Installed Task${tasks.length > 1 ? `s` : ``}`)
   CliUx.ux.table(tasks, {
     workflow_instance_id: {
       header: `Workflow Instance ID`,
@@ -234,6 +234,7 @@ export const printTasks = (tasks: Task[], flags: unknown): void => {
     },
     assign_to: {
       header: `Assignee`,
+      get: row => row.assign_to
     },
     task_type_major: {
       header: `Major`,
@@ -242,15 +243,17 @@ export const printTasks = (tasks: Task[], flags: unknown): void => {
       header: `Subscriber ID`,
     },
     tags: {
-      get: row => `${row.args.tags ?? ``}`
+      get: row => row.args.tags
     },
-    args: {},
+    args: {
+      get: row => row.args
+    },
   }, options)
 }
 
 export const printScheduledTasks = (tasks: ScheduledTask[], flags: unknown): void => {
   const options = { ...(flags as Record<string, unknown>) }
-  CliUx.ux.styledHeader(`Installed Task${tasks.length > 1 ? `s` : ``}`)
+  options.output ?? CliUx.ux.styledHeader(`Installed Task${tasks.length > 1 ? `s` : ``}`)
   CliUx.ux.table(tasks, {
     task_name: {
       header: `Task name`,
@@ -280,6 +283,7 @@ export const printScheduledTasks = (tasks: ScheduledTask[], flags: unknown): voi
     },
     assign_to: {
       header: `Assignee`,
+      get: row => row.assign_to
     },
     task_type_major: {
       header: `Major`,
@@ -288,15 +292,17 @@ export const printScheduledTasks = (tasks: ScheduledTask[], flags: unknown): voi
       header: `Subscriber ID`,
     },
     tags: {
-      get: row => `${row.args.tags ?? ``}`
+      get: row => row.args.tags
     },
-    args: {},
+    args: {
+      get: row => row.args
+    },
   }, options)
 }
 
 export const printTaskTypes = (taskTypes: TaskType[], flags: unknown, namespace: string): void => {
   const options = { ...(flags as Record<string, unknown>) }
-  CliUx.ux.styledHeader(`Installed Task Type${taskTypes.length > 1 ? `s` : ``} on ${namespace[0]?.toUpperCase() + namespace.slice(1)}`)
+  options.output ?? CliUx.ux.styledHeader(`Installed Task Type${taskTypes.length > 1 ? `s` : ``} on ${namespace[0]?.toUpperCase() + namespace.slice(1)}`)
   CliUx.ux.table(taskTypes, {
     name: {}
   }, options)
@@ -304,7 +310,7 @@ export const printTaskTypes = (taskTypes: TaskType[], flags: unknown, namespace:
 
 export const printMajors = (majors: Major[], flags: unknown, type: string, namespace: string): void => {
   const options = { ...(flags as Record<string, unknown>) }
-  CliUx.ux.styledHeader(`Major${majors.length > 1 ? `s` : ``} for ${type} on ${namespace[0]?.toUpperCase() + namespace.slice(1)}`)
+  options.output ?? CliUx.ux.styledHeader(`Major${majors.length > 1 ? `s` : ``} for ${type} on ${namespace[0]?.toUpperCase() + namespace.slice(1)}`)
   CliUx.ux.table(majors, {
     major: {
       header: `Major`,
@@ -314,7 +320,7 @@ export const printMajors = (majors: Major[], flags: unknown, type: string, names
 
 export const printMinors = (minors: Minor[], flags: unknown, type: string, latest: boolean, namespace: string): void => {
   const options = { ...(flags as Record<string, unknown>) }
-  CliUx.ux.styledHeader(`Minor${minors.length > 1 ? `s` : ``} for ${type} on ${namespace[0]?.toUpperCase() + namespace.slice(1)}`)
+  options.output ?? CliUx.ux.styledHeader(`Minor${minors.length > 1 ? `s` : ``} for ${type} on ${namespace[0]?.toUpperCase() + namespace.slice(1)}`)
   CliUx.ux.table(minors, {
     minor: {
       header: `${latest ? `Latest ` : ``}Minor`,
@@ -328,7 +334,7 @@ export const printMinors = (minors: Minor[], flags: unknown, type: string, lates
 
 export const printDump = (taskTypes: TaskTypeDump[], flags: unknown,namespace: string): void => {
   const options = { ...(flags as Record<string, unknown>) }
-  CliUx.ux.styledHeader(`Latest versions of task types on ${namespace}`)
+  options.output ?? CliUx.ux.styledHeader(`Latest versions of task types on ${namespace}`)
   CliUx.ux.table(taskTypes, {
     type: {},
     major: {},
@@ -341,7 +347,7 @@ export const printDump = (taskTypes: TaskTypeDump[], flags: unknown,namespace: s
 
 export const printTaskGroups = (groups: TaskGroup[], flags: unknown): void => {
   const options = { ...(flags as Record<string, unknown>) }
-  CliUx.ux.styledHeader(`Task Groups`)
+  options.output ?? CliUx.ux.styledHeader(`Task Groups`)
   CliUx.ux.table(groups, {
     group_name: {
       header: `Group Name`,
@@ -366,6 +372,53 @@ export const printTaskGroups = (groups: TaskGroup[], flags: unknown): void => {
       header: `Task Type Name`
     },
   }, options)
+}
+
+export const printAnalytics = (analytics: WorkflowEvents, flags: unknown, parse: boolean): void => {
+  const options = { ...(flags as Record<string, unknown>)}
+  options.output ?? CliUx.ux.log(`=> Showing ${analytics?.length} events`)
+  CliUx.ux.table(analytics, {
+    workflow_id: {
+      header: `Workflow ID`,
+    },
+    source_type: {
+      header: `Type`,
+    },
+    category: {},
+    workflow_instance_id: {
+      header: `Instance ID`,
+    },
+    id: {
+      header: `Analytic ID`,
+      extended: true
+    },
+    timestamp: {},
+    user_id: {
+      header: `User ID`,
+    },
+    content_type: {
+      header: `Content Type`,
+      extended: true,
+    },
+    content: {
+      get: row => {
+        if (parse) {
+          return parseContent(row)
+        } else {
+          return row.content
+        }
+      }
+    },
+  }, options)
+  options.output ?? CliUx.ux.log(`=> Showing ${analytics?.length} events`)
+}
+
+const parseContent = (row: WorkflowEvent): string => {
+  if (row.content_type === `application/json` || row.content_type == `application/vnd.relay.tasks.parameters.v2+json`) {
+    return JSON.stringify(JSON.parse(row.content), null, 2)
+  } else {
+    return row.content
+  }
 }
 
 const mappings = {


### PR DESCRIPTION
- Bug fix: when calling a list command with `--output=json` flag and attempting to pipe the output into `jq`, you get an error due to the table headers being printed in the output.  I added condition in each print function to first check that the user is not trying to output a certain format (json, csv, or yaml) before printing the table header
- Add `enableJsonFlag` to list commands where it was missing to allow user to use `--json` for all list commands
- Reorder args in `task groups create` to match order in `task start`