### PR TITLE
Unhide capsule commands, but keep top level help hidden

### DIFF
--- a/src/commands/alice/ticketer/start.ts
+++ b/src/commands/alice/ticketer/start.ts
@@ -19,8 +19,6 @@ export default class AliceTicketerStartCommand extends CreateCommand {
   static description = `Start an Alice ticketing workflow with the given configuration`
   static strict = false
 
-  static hidden = true
-
   static flags = {
     ...flags.subscriber,
     ...flags.installFlags,

--- a/src/commands/alice/webhook/start.ts
+++ b/src/commands/alice/webhook/start.ts
@@ -15,8 +15,6 @@ export default class AliceWebhookStartCommand extends Command {
   static description = `Start an Alice webhook task with the given configuration`
   static strict = false
 
-  static hidden = true
-
   static flags = {
     ...flags.subscriber,
     name: flags.string({

--- a/src/commands/alice/webhook/stop.ts
+++ b/src/commands/alice/webhook/stop.ts
@@ -12,8 +12,6 @@ export default class AliceWebhookStopCommand extends Command {
   static description = `Stop a running Alice webhook task`
   static strict = false
 
-  static hidden = true
-
   static flags = {
     ...flags.subscriber
   }

--- a/src/commands/hotsos/start.ts
+++ b/src/commands/hotsos/start.ts
@@ -15,8 +15,6 @@ export default class HosSOSStartCommand extends Command {
   static description = `Start a HotSOS poller with the given configuration`
   static strict = false
 
-  static hidden = true
-
   static flags = {
     ...flags.subscriber,
     name: flags.string({

--- a/src/commands/hotsos/stop.ts
+++ b/src/commands/hotsos/stop.ts
@@ -12,8 +12,6 @@ export default class HotSOSStopCommand extends Command {
   static description = `Stop a running HotSOS poller task`
   static strict = false
 
-  static hidden = true
-
   static flags = {
     ...flags.subscriber
   }

--- a/src/commands/task/delete.ts
+++ b/src/commands/task/delete.ts
@@ -14,7 +14,6 @@ const { Confirm } = require('enquirer') // eslint-disable-line quotes
 
 export default class TaskDeleteCommand extends Command {
   static description = `Delete a running or scheduled task`
-  static hidden = true
 
   static flags = {
     ...flags.subscriber,

--- a/src/commands/task/groups/create.ts
+++ b/src/commands/task/groups/create.ts
@@ -15,8 +15,6 @@ export default class TaskGroupsCreateCommand extends Command {
   static description = `Create a task group`
   static strict = false
 
-  static hidden = true
-
   static flags = {
     ...flags.subscriber,
   }

--- a/src/commands/task/groups/delete.ts
+++ b/src/commands/task/groups/delete.ts
@@ -17,8 +17,6 @@ export default class TaskGroupDeleteCommand extends Command {
   static description = `Delete a task group`
   static strict = false
 
-  static hidden = true
-
   static flags = {
     ...flags.subscriber,
     ...CliUx.ux.table.flags(),

--- a/src/commands/task/groups/list.ts
+++ b/src/commands/task/groups/list.ts
@@ -18,8 +18,6 @@ export default class TaskGroupsListCommand extends Command {
   static strict = false
   static enableJsonFlag = true
 
-  static hidden = true
-
   static flags = {
     ...flags.subscriber,
     ...CliUx.ux.table.flags(),

--- a/src/commands/task/list.ts
+++ b/src/commands/task/list.ts
@@ -18,7 +18,6 @@ export default class TaskListCommand extends Command {
   static description = `List task configurations`
   static enableJsonFlag = true
 
-  static hidden = true
 
   static flags = {
     ...flags.subscriber,

--- a/src/commands/task/schedule.ts
+++ b/src/commands/task/schedule.ts
@@ -16,7 +16,6 @@ export default class TasksScheduleCommand extends Command {
 
   static description = `Schedule a task with the given configuration`
   static strict = false
-  static hidden = true
 
   static flags = {
     ...flags.subscriber,

--- a/src/commands/task/start.ts
+++ b/src/commands/task/start.ts
@@ -16,7 +16,6 @@ export default class TasksStartCommand extends Command {
 
   static description = `Start a task with the given configuration`
   static strict = false
-  static hidden = true
 
   static flags = {
     ...flags.subscriber,

--- a/src/commands/task/types/create.ts
+++ b/src/commands/task/types/create.ts
@@ -25,7 +25,6 @@ export default class TaskTypesCreateCommand extends Command {
   static description = `Create a task type. Must have admin priviledges and RELAY_ADMIN_TOKEN env variable set to run this command.`
   static strict = false
 
-  static hidden = true
 
   static flags = {
     ...flags.subscriber,

--- a/src/commands/task/types/delete.ts
+++ b/src/commands/task/types/delete.ts
@@ -17,7 +17,6 @@ export default class TaskTypesDeleteCommand extends Command {
   static description = `Delete a task type. Must have admin priviledges and RELAY_ADMIN_TOKEN env variable set to run this command.`
   static strict = false
 
-  static hidden = true
 
   static flags = {
     ...flags.subscriber

--- a/src/commands/task/types/dump.ts
+++ b/src/commands/task/types/dump.ts
@@ -19,7 +19,6 @@ export default class TaskTypesDumpCommand extends Command {
   static strict = false
   static enableJsonFlag = true
 
-  static hidden = true
 
   static flags = {
     ...flags.subscriber,

--- a/src/commands/task/types/fetch.ts
+++ b/src/commands/task/types/fetch.ts
@@ -14,8 +14,6 @@ export default class TaskTypesFetchCommand extends Command {
   static description = `Fetch a specific minor`
   static strict = false
 
-  static hidden = true
-
   static flags = {
     ...flags.subscriber,
     ...CliUx.ux.table.flags()

--- a/src/commands/task/types/list/majors.ts
+++ b/src/commands/task/types/list/majors.ts
@@ -18,8 +18,6 @@ export default class TaskTypesListMajorsCommand extends Command {
   static strict = false
   static enableJsonFlag = true
 
-  static hidden = true
-
   static flags = {
     ...flags.subscriber,
     ...CliUx.ux.table.flags(),

--- a/src/commands/task/types/list/minors.ts
+++ b/src/commands/task/types/list/minors.ts
@@ -18,8 +18,6 @@ export default class TaskTypesListMinorsCommand extends Command {
   static strict = false
   static enableJsonFlag = true
 
-  static hidden = true
-
   static flags = {
     ...flags.subscriber,
     ...CliUx.ux.table.flags()

--- a/src/commands/task/types/list/types.ts
+++ b/src/commands/task/types/list/types.ts
@@ -18,8 +18,6 @@ export default class TaskTypesListTypesCommand extends Command {
   static strict = false
   static enableJsonFlag = true
 
-  static hidden = true
-
   static flags = {
     ...flags.subscriber,
     ...CliUx.ux.table.flags()

--- a/src/commands/task/types/update/major.ts
+++ b/src/commands/task/types/update/major.ts
@@ -25,8 +25,6 @@ export default class TaskTypesUpdateMajorCommand extends Command {
   static description = `Update a task type's major. Must have admin priviledges and RELAY_ADMIN_TOKEN env variable set to run this command.`
   static strict = false
 
-  static hidden = true
-
   static flags = {
     ...flags.subscriber,
     key: flags.string ({

--- a/src/commands/task/types/update/minor.ts
+++ b/src/commands/task/types/update/minor.ts
@@ -25,8 +25,6 @@ export default class TaskTypesUpdateMinorCommand extends Command {
   static description = `Update a task type. Must have admin priviledges and RELAY_ADMIN_TOKEN env variable set to run this command.`
   static strict = false
 
-  static hidden = true
-
   static flags = {
     ...flags.subscriber,
     key: flags.string ({

--- a/src/lib/help.ts
+++ b/src/lib/help.ts
@@ -20,10 +20,44 @@ export default class RelayHelp extends Help {
     super.showHelp(args)
   }
 
+  protected async customShowRootHelp(): Promise<void> {
+    let rootTopics = super.sortedTopics
+    let rootCommands = super.sortedCommands
+
+    const state = this.config.pjson?.oclif?.state
+    if (state) {
+      super.log(state === `deprecated` ? `${super.config.bin} is deprecated` : `${super.config.bin} is in ${state}.\n`)
+    }
+
+    super.log(super.formatRoot())
+    super.log(``)
+
+    // take out top level help for capsule commands
+    rootTopics = rootTopics.filter((t) => !t.name.includes(`task`))
+    rootTopics = rootTopics.filter((t) => !t.name.includes(`alice`))
+    rootTopics = rootTopics.filter((t) => !t.name.includes(`hotsos`))
+
+    if (!this.opts.all) {
+      rootTopics = rootTopics.filter((t) => !t.name.includes(`:`))
+      rootCommands = rootCommands.filter((c) => !c.id.includes(`:`))
+    }
+
+    if (rootTopics.length > 0) {
+      super.log(super.formatTopics(rootTopics))
+      super.log(``)
+    }
+
+    if (rootCommands.length > 0) {
+      rootCommands = rootCommands.filter((c) => c.id)
+      super.log(super.formatCommands(rootCommands))
+      super.log(``)
+    }
+  }
+
   // display the root help of a CLI
   async showRootHelp(): Promise<void> {
     CliUx.ux.log(RELAY)
-    super.showRootHelp()
+    this.customShowRootHelp()
   }
 
   // display help for a topic


### PR DESCRIPTION
Unhide all capsule commands, but wanted to still keep them hidden from the top level -h (`relay -h`), yet still allow help flag to be used on all other levels of capsule commands (`relay task -h`, `relay task types -h`, etc.)